### PR TITLE
#243: highlight active table row

### DIFF
--- a/grails-app/views/bioActivity/_createEditActivityBody.gsp
+++ b/grails-app/views/bioActivity/_createEditActivityBody.gsp
@@ -5,12 +5,18 @@
 .overflow-table {
     overflow-x: visible;
 }
+
 table .observations {
     position: relative;
     height:400px;
     overflow-x: visible;
     width:99%;
 }
+
+.observations tr:hover td{
+    border: 2px solid #ffa;
+}
+
 table tr td:nth-child(odd), thead th:nth-child(odd) {
     background:#f5f5f5;
 }


### PR DESCRIPTION
Adding a highlight to table row visible when adding a new survey result or editing an existing one. 
There are no changes to the behaviour of the column in this PR.

When you hover over a row and start entering an observation, this row will have a yellow highlight like so:
![Screenshot from 2023-05-31 11-25-55](https://github.com/biodiversitydata-se/biocollect/assets/26426498/26ea32a1-0673-4db7-b27a-6eb1856332fd)
